### PR TITLE
pyjwkest in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
         "cryptojwt>=0.7.13",
         'oidcmsg>=0.6.6',
         'oidcservice>=0.6.7',
-        'oidcendpoint>=0.12.2'
+        'oidcendpoint>=0.12.2',
+        'pyjwkest>=1.4.0'
     ],
     tests_require=[
         "responses",


### PR DESCRIPTION
Otherwise

````
tests/utils.py:7: in <module>
    from jwkest.jws import factory

E   ModuleNotFoundError: No module named 'jwkest'
````