### PR TITLE
Fix oauth authorization server metadata at openid-federation configuration

### DIFF
--- a/src/fedservice/appserver/__init__.py
+++ b/src/fedservice/appserver/__init__.py
@@ -115,8 +115,7 @@ class ServerEntity(ServerUnit):
         return self
 
     def get_metadata(self, *args):
-        # static ! Should this be done dynamically ?
-        return {'openid_provider': self.context.provider_info}
+        return {self.name: self.context.provider_info}
 
     def setup_authz(self):
         authz_spec = self.config.get("authz")

--- a/src/fedservice/appserver/oauth2/__init__.py
+++ b/src/fedservice/appserver/oauth2/__init__.py
@@ -1,0 +1,4 @@
+from fedservice.appserver import ServerEntity
+
+class Oauth2ServerEntity(ServerEntity):
+    name = "oauth_authorization_server"


### PR DESCRIPTION
While setting a Server Entity for oauth_authorization_server it conflicts metadata with "openid_provider".