### PR TITLE
Fix oauth client metadata for openid-federation configuration

### DIFF
--- a/src/fedservice/appclient/__init__.py
+++ b/src/fedservice/appclient/__init__.py
@@ -112,7 +112,7 @@ class ClientEntity(ClientUnit):
         _registration = Registration(upstream_get=_fed_registration.upstream_get,
                                      conf=_fed_registration.conf)
         request = _registration.construct_request()
-        return {'openid_relying_party': request.to_dict()}
+        return {self.name: request.to_dict()}
 
     def do_request(
             self,

--- a/src/fedservice/appclient/oauth2/__init__.py
+++ b/src/fedservice/appclient/oauth2/__init__.py
@@ -1,0 +1,4 @@
+from fedservice.appclient import ClientEntity
+
+class Oauth2ClientEntity(ClientEntity):
+    name = "oauth_client"


### PR DESCRIPTION
While setting a Client Entity for oauth/_client  it conflicts metadata with "openid_relaying_party".