### PR TITLE
Minor type fix in list query parameter checks

### DIFF
--- a/src/fedservice/entity/server/list.py
+++ b/src/fedservice/entity/server/list.py
@@ -63,7 +63,7 @@ class List(Endpoint):
                         matched_entity_ids.add(entity_id)
                         continue
                 if "entity_type" in request:
-                    if request["entity_type"] in item["entity_type"]:
+                    if request["entity_type"] in item["entity_types"]:
                         matched_entity_ids.add(entity_id)
 
             # I don't expect to know about trust marks from the registration


### PR DESCRIPTION
The entity attribute appears to be called 'entity_types' instead of 'entity_type' (according to setup_federation/get_info.py)